### PR TITLE
Migrate authors column to text type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore vendor bundle
+/vendor/bundle
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     popper_js (1.12.9)
     public_suffix (3.0.2)
     puma (3.11.3)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)
@@ -181,7 +181,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -239,4 +239,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/db/migrate/20180719192124_authors_use_text.rb
+++ b/db/migrate/20180719192124_authors_use_text.rb
@@ -1,0 +1,9 @@
+class AuthorsUseText < ActiveRecord::Migration[5.2]
+  def up
+    change_column :ruby_gems, :authors, :text
+  end
+
+  def down
+    change_column :ruby_gems, :authors, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_12_183616) do
+ActiveRecord::Schema.define(version: 2018_07_19_192124) do
 
   create_table "ruby_gems", force: :cascade do |t|
     t.string "name"
-    t.string "authors"
+    t.text "authors"
     t.text "info"
     t.integer "downloads"
     t.datetime "created_at", null: false


### PR DESCRIPTION
This adds a migration that changes the `authors` column from string to text.  This is neccesary for `db:seed` to complete successfully on databases other than sqlite, since many author fields exceed 255 characters in length.

Also bumps sprockets to 3.7.2 due to a vulnerability